### PR TITLE
Leder use added to arky CLI

### DIFF
--- a/arky/cli/__init__.py
+++ b/arky/cli/__init__.py
@@ -53,10 +53,11 @@ class Data(object):
 
 	def __init__(self):
 		self.delegate = {}
+		self.ledger = {}
 		self.account = {}
 		self.firstkeys = {}
 		self.secondkeys = {}
-		self.ledger_dpath = None
+		# self.ledger_dpath = None
 		self.executemode = False
 		object.__setattr__(self, "daemon", None)
 		object.__setattr__(self, "escrowed", False)
@@ -194,11 +195,18 @@ def checkSecondKeys():
 
 
 def floatAmount(amount):
+
+	status = DATA.account if len(DATA.account) else \
+	         DATA.ledger  if len(DATA.ledger)  else \
+			 {}
+	if not status:
+		return False
+
 	if amount.endswith("%"):
 		if DATA.executemode:
-			balance = float(DATA.account.get("balance", 0.))
+			balance = float(status.get("balance", 0.))
 		else:
-			resp = rest.GET.api.accounts.getBalance(address=DATA.account["address"])
+			resp = rest.GET.api.accounts.getBalance(address=status["address"])
 			if resp["success"]:
 				balance = float(resp["balance"])
 			else:

--- a/arky/cli/__init__.py
+++ b/arky/cli/__init__.py
@@ -56,7 +56,8 @@ class Data(object):
 		self.account = {}
 		self.firstkeys = {}
 		self.secondkeys = {}
-		self.executemode =False
+		self.ledger_dpath = None
+		self.executemode = False
 		object.__setattr__(self, "daemon", None)
 		object.__setattr__(self, "escrowed", False)
 

--- a/arky/cli/account.py
+++ b/arky/cli/account.py
@@ -115,6 +115,7 @@ def unlink(param):
 	DATA.firstkeys.clear()
 	DATA.secondkeys.clear()
 	DATA.escrowed = False
+	DATA.ledger_dpath = None
 
 
 def status(param):

--- a/arky/cli/account.py
+++ b/arky/cli/account.py
@@ -112,10 +112,11 @@ def link(param):
 
 def unlink(param):
 	DATA.account.clear()
+	DATA.delegate.clear()
 	DATA.firstkeys.clear()
 	DATA.secondkeys.clear()
 	DATA.escrowed = False
-	DATA.ledger_dpath = None
+	# DATA.ledger_dpath = None
 
 
 def status(param):

--- a/arky/cli/delegate.py
+++ b/arky/cli/delegate.py
@@ -31,7 +31,7 @@ from . import checkSecondKeys
 from . import checkRegisteredTx
 
 from .account import link as _link
-from .account import unlink as _unlink
+from .account import unlink # as _unlink
 
 import io
 import os
@@ -65,9 +65,8 @@ def link(param):
 		unlink(param)
 
 
-def unlink(param):
-	_unlink(param)
-	DATA.delegate.clear()
+# def unlink(param):
+# 	_unlink(param)
 
 
 def status(param):

--- a/arky/cli/ledger.py
+++ b/arky/cli/ledger.py
@@ -3,25 +3,90 @@
 
 """
 Usage: 
-    ledger link <derivation_path>
+    ledger link [-i <index> -r <rank>]
+    ledger unlink
+    ledger status
+    ledger send <amount> <address> [<message>]
 
 Options:
+-i <index> --account-index <index>  ledger account index  [default: 0]
+-r <rank> --address-rank <rank>     ledger address rank   [default: 0]
 
 Subcommands:
+    link     : link to account.
+    status   : show information about linked account.
 """
 
 from .. import rest
 from .. import cfg
 from .. import util
 from .. import ldgr
+from .. import slots
 
 from . import __PY3__
+from . import PROMPT
 from . import DATA
+from . import parse
+from . import __name__ as __root_name__
+from . import floatAmount
+
+from .account import status
+from .account import unlink
+from .account import _send
 
 import arky
+import sys
+
+
+
+def _return():
+	sys.stdout.write("Ledger not available on %s network\n" % cfg.network)
+	PROMPT.module = sys.modules[__root_name__]
+	parse(["ledger", ".."])
+
 
 def _whereami():
-	return "ledger"
+	if hasattr(cfg, "slip44"):
+		if DATA.ledger_dpath:
+			return "ledger[%s]" % util.shortAddress(DATA.account["address"])
+		else:
+			return "ledger"
+	else:
+		_return()
+		return ""
+
 
 def link(param):
-	pass
+	if hasattr(cfg, "slip44"):
+		ledger_dpath = "44'/"+cfg.slip44+"'/%(--account-index)s'/0/%(--address-rank)s" % param
+		try:
+			DATA.account = ldgr.getPublicKeyAddress(ldgr.parse_bip32_path(ledger_dpath))
+			DATA.ledger_dpath = ledger_dpath
+		except:
+			sys.stdout.write("Ledger key is not ready, try again...\n")
+			unlink(param)
+	else:
+		_return()
+
+def send(param):
+
+	if DATA.account:
+		amount = floatAmount(param["<amount>"])
+		if amount:
+			sys.stdout.write("Use ledger key to confirm or or cancel :\n")
+			sys.stdout.write("    Send %(amount).8f %(token)s to %(recipientId)s ?\n" % \
+		                    {"token": cfg.token, "amount": amount, "recipientId": param["<address>"]})
+			tx = dict(
+				type=0,
+				timestamp=int(slots.getTime()),
+				fee=cfg.fees["send"],
+				amount=amount*100000000,
+				recipientId=param["<address>"],
+				vendorField=param["<message>"],
+			)
+			try:
+				tx = ldgr.signTx(tx, DATA.ledger_dpath)
+			except:
+				sys.stdout.write("Ledger key is not ready, try again...\n")
+			else:
+				_send(tx)

--- a/arky/net/ark.net
+++ b/arky/net/ark.net
@@ -9,6 +9,7 @@
   "compressed": true,
   "wif": "aa",
   "marker": "17",
+  "slip44": "111",
   "bip32": {
     "private": 76066276,
     "public": 76067358

--- a/arky/rest.py
+++ b/arky/rest.py
@@ -196,8 +196,10 @@ def use(network, **kw):
 		pass
 
 	with open(os.path.join(ROOT, "net", network+".net"), "r" if __PY3__ else "rb") as _in:
+		cfg.__dict__.pop("slip44", None)
 		data = json.load(_in)
 		data.update(**kw)
+		# if "slip44" not in data:
 		# save json data as variables in cfg.py module
 		cfg.__dict__.update(data)
 		# for https uses

--- a/arky/util.py
+++ b/arky/util.py
@@ -163,7 +163,7 @@ def prettyfy(dic, tab="    "):
 			else:
 				result += tab + "%s: %s" % (k.rjust(maxlen),v)
 			result += "\n"
-		return result
+		return result.encode("ascii", errors="replace").decode()
 
 def prettyPrint(dic, tab="    ", log=True):
 	pretty = prettyfy(dic, tab)

--- a/readme.rst
+++ b/readme.rst
@@ -170,28 +170,20 @@ Link account
                    balance: 2637000000
   hot@toxy/account[18160...4874X]>
 
+Use Ledger Nano S
+^^^^^^^^^^^^^^^^^
 
-Ledger Nano S
-=============
+::
 
->>> import arky
->>> from arky import slots
->>> from arky import rest
->>> rest.use("ark")
->>> recipientId = "..." # put your recipient address here
->>> derivationPath = "44'/111'/0'/0/0"
->>> tx = dict(
-...    recipientId=recipientId,
-...    vendorField="Tx using ledger with arky !",
-...    timestamp=int(slots.getTime()),
-...    type=0,
-...    amount=1,
-...    fee=10000000
-...)
->>> # launch ark app on ledger
->>> ldgr.signTx(tx, derivationPath)
->>> # valid the transaction on ledger
->>> arky.core.sendPayload(tx)
+  hot@ark/network> ledger link
+  hot@ark/ledger[AerGA...VbMft]> send 1 AUahWfkfr5J4tYakugRbfow7RWVTK35GPW "send 1 ARK from ledger using arky CLI"
+  Use ledger key to confirm or or cancel :
+      Send 1.00000000 ARK to AUahWfkfr5J4tYakugRbfow7RWVTK35GPW ?
+      Broadcasting transaction...
+           broadcast: 100.0%
+      transactionIds: ['34d4ce9dea2dd4f52e8d6af1977d5f00488694ecbdaf7c45f70a7c46c078c744']
+             success: True
+  hot@ark/ledger[AerGA...VbMft]>
 
 Author
 ======


### PR DESCRIPTION
Significant improvement of ledger use

```hot@ark/account> ledger link
hot@ark/ledger[AerGA...VbMft]> send 100% AUahWfkfr5J4tYakugRbfow7RWVTK35GPW "send 100% ARK from ledger using arky CLI"
Use ledger key to confirm or or cancel :
    Send 15.50000000 ARK to AUahWfkfr5J4tYakugRbfow7RWVTK35GPW ?
    Broadcasting transaction...
    transactionIds: ['a48311aafa8da7643fea77b368dfc6641a618c88fe03a9efe835406492e0a260']
           success: True
         broadcast: 100.0%
hot@ark/ledger[AerGA...VbMft]>```

Available transactions :  
 * [x] send
 * [ ] vote
