### PR TITLE
Update __init__.py

### DIFF
--- a/arky/util/__init__.py
+++ b/arky/util/__init__.py
@@ -13,6 +13,8 @@ def getTokenPrice(token, fiat="usd"):
         return float(cmc_ark[0]["price_%s" % fiat])
     except requests.ConnectionError:
         return 1
+    except KeyError:
+         return("Currency not found")
 
 
 def getArkFiatPrice(fiat):


### PR DESCRIPTION
Previously 
print getTokenPrice("ark")
print getTokenPrice("notarealtoken")

would return an error for tokens not found on coinmarketcap, added a KeyError exception