### PR TITLE
Use python's built-in pow() method

### DIFF
--- a/arky/ark/crypto.py
+++ b/arky/ark/crypto.py
@@ -19,7 +19,6 @@ from ..util import unpack_bytes
 from ..util import pack_bytes
 from ..util import hexlify
 from ..util import unhexlify
-from ..util import powMod
 
 if not __PY3__:
 	from StringIO import StringIO
@@ -50,8 +49,8 @@ def uncompressEcdsaPublicKey(pubkey):
 	p = 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f
 	y_parity = int(pubkey[:2]) - 2
 	x = int(pubkey[2:], 16)
-	a = (powMod(x, 3, p) + 7) % p
-	y = powMod(a, (p + 1) // 4, p)
+	a = (pow(x, 3, p) + 7) % p
+	y = pow(a, (p + 1) // 4, p)
 	if y % 2 != y_parity:
 		y = -y % p
 	# return result as der signature (no 0x04 preffix)

--- a/arky/util.py
+++ b/arky/util.py
@@ -49,17 +49,6 @@ def unhexlify(data):
 	return result if isinstance(result, bytes) else result.encode()
 
 
-def powMod(x, y, z):
-	"Calculate (x ** y) % z efficiently."
-	number = 1
-	while y:
-		if y & 1:
-			number = number * x % z
-		y >>= 1
-		x = x * x % z
-	return number
-
-
 ###############
 ## http util ##
 ###############


### PR DESCRIPTION
This is another small PR to use python's built-in [`pow()`](https://docs.python.org/2.7/library/functions.html#pow) method instead of using a custom `powMod()` which will be faster since it is implemented in C.