### PR TITLE
Change datetime imports in slots and util files

### DIFF
--- a/arky/slots.py
+++ b/arky/slots.py
@@ -1,32 +1,40 @@
 # -*- encoding: utf8 -*-
 # © Toons
 
-from . import cfg
-
-import datetime
 import pytz
+
+from arky import cfg
+
+from datetime import datetime, timedelta
+
 
 def getTimestamp(**kw):
 	delta = datetime.timedelta(**kw)
-	return getTime(datetime.datetime.now(pytz.UTC) - delta)
+	return getTime(datetime.now(pytz.UTC) - delta)
+
 
 def getTime(time=None):
-	delta = (datetime.datetime.now(pytz.UTC) if not time else time) - cfg.begintime
+	delta = (datetime.now(pytz.UTC) if not time else time) - cfg.begintime
 	return delta.total_seconds()
 
+
 def getRealTime(epoch=None):
-	epoch = getTime() if epoch == None else epoch
-	return cfg.begintime + datetime.timedelta(seconds=epoch)
+	epoch = getTime() if epoch is None else epoch
+	return cfg.begintime + timedelta(seconds=epoch)
+
 
 def getSlot(epoch=None):
-	epoch = getTime() if epoch == None else epoch
-	return int(epoch//cfg.blocktime)
+	epoch = getTime() if epoch is None else epoch
+	return int(epoch // cfg.blocktime)
+
 
 def getSlotTime(slot):
-	return slot*cfg.blocktime
+	return slot * cfg.blocktime
+
 
 def getSlotRealTime(slot):
-	return getRealTime(slot*cfg.blocktime)
+	return getRealTime(slot * cfg.blocktime)
+
 
 def getLastSlot(slot):
 	return slot + cfg.delegate

--- a/arky/util.py
+++ b/arky/util.py
@@ -7,9 +7,12 @@ import io
 import json
 import logging
 import os
+import pytz
 import struct
 import sys
 import threading
+
+from datetime import datetime, timedelta
 
 from arky import cfg, HOME, rest, ROOT, slots
 
@@ -119,10 +122,10 @@ def getVoteForce(address, **kw):
 	balance = kw.pop("balance", 0) / 100000000.
 	if not balance:
 		balance = float(rest.GET.api.accounts.getBalance(address=address, returnKey="balance")) / 100000000.
-	delta = slots.datetime.timedelta(**kw)
+	delta = timedelta(**kw)
 	if delta.total_seconds() < 86400:
 		return balance
-	now = slots.datetime.datetime.now(slots.pytz.UTC)
+	now = datetime.now(pytz.UTC)
 	timestamp_limit = slots.getTime(now - delta)
 	# get transaction history
 	history = getHistory(address, timestamp_limit)


### PR DESCRIPTION
This is super minor, needed to do a no-brainer ticket to put my mind off while learning and trying to understand how crypto.py works (encryptions, hexlify, pack etc.) in order to know how to write tests.

This PR just changes:
- instead of importing datetime and pytz from slots.py I import them from their main library
- flake8 changes (no spaces this time! :))