### PR TITLE
Tests for ldgr.py and mocking dongle

### DIFF
--- a/arky/ldgr.py
+++ b/arky/ldgr.py
@@ -110,20 +110,25 @@ def getPublicKey(dongle_path, debug=False):
 	return util.hexlify(data[1:len_pkey + 1])
 
 
-def signTx(tx, dongle_path, debug=False):
+def signTx(tx, path, debug=False):
 	"""
 	Sign a transaction. It generates the signature accordingly to derivation path
 	and computes the id of the transaction. The tx is then updated and returned.
 
 	Argument:
 	tx -- a dict object containing explicit fields and values defining a valid transaction
-	dongle_path -- a derivation path
+	path -- a derivation path
 
 	Keyword argument:
 	debug -- flag to activate debug messages from ledger key [default: False]
 
 	Return dict
 	"""
+	dongle_path = parseBip32Path(path)
+
+	if tx.get("senderPublicKey"):
+		tx["senderPublicKey"] = getPublicKey(dongle_path)
+
 	apdu1, apdu2 = buildTxApdu(dongle_path, arky.core.crypto.getBytes(tx))
 	dongle = getDongle(debug)
 	if apdu2:

--- a/arky/ldgr.py
+++ b/arky/ldgr.py
@@ -104,7 +104,7 @@ def getPublicKey(dongle_path, debug=False):
 	"""
 	dongle = getDongle(debug)
 	pkey_apdu = buildPkeyApdu(dongle_path)
-	data = dongle.exchange(pkey_apdu)
+	data = bytes(dongle.exchange(pkey_apdu))
 	dongle.close()
 	len_pkey = util.basint(data[0])
 	return util.hexlify(data[1:len_pkey + 1])

--- a/test/test_ldgr.py
+++ b/test/test_ldgr.py
@@ -53,11 +53,8 @@ class TestLdgr(unittest.TestCase):
         """
         rest.use("dark")
 
-        dongle_path = ldgr.parseBip32Path(self.path)
         with patch.object(ldgr, 'getDongle', return_value=MockedHIDDongleHIDAPI()):
-            public_key = ldgr.getPublicKey(dongle_path)
             tx = dict(
-                senderPublicKey=public_key,
                 vendorField="First Tx using ledger with arky!",
                 timestamp=int(slots.getTime()),
                 type=0,
@@ -65,7 +62,7 @@ class TestLdgr(unittest.TestCase):
                 recipientId='DUGvQBxLzQqrNy68asPcU3stWQyzVq8G49',
                 fee=10000000
             )
-            signed_tx = ldgr.signTx(tx, dongle_path)
+            signed_tx = ldgr.signTx(tx, self.path)
         assert signed_tx
 
 

--- a/test/test_ldgr.py
+++ b/test/test_ldgr.py
@@ -1,8 +1,14 @@
 # -*- encoding: utf8 -*-
 import unittest
-from unittest.mock import patch
 
 from arky import ldgr, rest, slots
+
+from six import PY3
+
+if PY3:
+    from unittest.mock import patch
+else:
+    from mock import patch
 
 
 """


### PR DESCRIPTION
I got my ledger a month early so was able to test things. I decided to mock the dongle because I suspect we can trust ledger they have done all the tests on their end so in our tests it should be OK to return what we expect to get back from the ledger, hence the simple mock object.

Despite tests using a mocked dongle, I've tested both tests using a real ledger and it worked. You can see the transactions here: https://dexplorer.ark.io/wallets/DFP2cKBdEWxh3mWahhHDFVS5gjj5HpFFbn

Also, I don't care about exposing anything sensitive from my ledger in these tests because I don't hold anything other than this dark wallet there. :)