### PR TITLE
Modify arky CLI + create Arky exceptions + first batch of tests for Arky CLI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ python:
   - "3.5"
   - "3.6"
 install:
-  - pip install pipenv
+  - pip install pipenv==11.1.3
   - pipenv install --dev --skip-lock
   - pip install -e .
 script:

--- a/arky/cli/__init__.py
+++ b/arky/cli/__init__.py
@@ -36,11 +36,10 @@ class CLI:
 		"""
 		Prompt showing current location in the CLI
 		"""
-		whereami = self.module._whereami()
 		return "{hoc}@{net}/{wai}>".format(
 			hoc="hot" if cfg.hotmode else "cold",
 			net=cfg.network,
-			wai=whereami
+			wai=self.module._whereami()
 		)
 
 	def start(self):

--- a/arky/cli/__init__.py
+++ b/arky/cli/__init__.py
@@ -1,6 +1,8 @@
 # -*- encoding: utf8 -*-
 # © Toons
-
+"""
+Available commands: network, account, delegate, ledger
+"""
 import io
 import os
 import sys
@@ -14,33 +16,127 @@ from builtins import input
 
 import arky
 from arky import __version__, __FROZEN__, HOME, ROOT, rest, util, cfg
+from arky.exceptions import ParserException
 
 PACKAGES = ['network', 'account', 'delegate', 'ledger']
 
 
-class _Prompt(object):
-	enable = True
+def _whereami():
+	return ""
 
-	def __setattr__(self, attr, value):
-		object.__setattr__(self, attr, value)
 
-	def __repr__(self):
+class CLI:
+
+	def __init__(self):
+		self.enabled = True
+		self.module = sys.modules[__name__]
+
+	@property
+	def prompt(self):
+		"""
+		Prompt showing current location in the CLI
+		"""
+		whereami = self.module._whereami()
 		return "{hoc}@{net}/{wai}>".format(
 			hoc="hot" if cfg.hotmode else "cold",
 			net=cfg.network,
-			wai=self.module._whereami()
+			wai=whereami
 		)
 
-	def state(self, state=True):
-		_Prompt.enable = state
+	def start(self):
+		"""
+		Start an interactive CLI
+		"""
+		_handler = snapLogging()
+		sys.stdout.write(
+			'Welcome to arky-cli [Python %(python)s / arky %(arky)s]\n' % {
+				"python": sys.version.split()[0],
+				"arky": __version__,
+			}
+		)
+		sys.stdout.write("%s\n" % self.module.__doc__.strip())
 
+		while True:
+			try:
+				command = input(self.prompt)
+			except ParserException as error:
+				sys.stdout.write("%s\n" % error)
+				argv = [".."]
+			except EOFError:
+				argv = ["EXIT"]
+			else:
+				argv = shlex.split(command)
 
-PROMPT = _Prompt()
-PROMPT.module = sys.modules[__name__]
+			if len(argv) and self.enabled:
+				cmd, arg = self.parse(argv)
+				if not cmd:
+					break
+				elif arg:
+					if "link" not in argv:
+						logging.info(command)
+					else:
+						command = censorship(argv)
+						logging.info(command)
+					try:
+						cmd(arg)
+					except ParserException as error:
+						# pass because we already log the exception when calling `self.prompt`
+						pass
+					except Exception as error:
+						if hasattr(error, "__traceback__"):
+							sys.stdout.write("".join(traceback.format_tb(error.__traceback__)).rstrip() + "\n")
+						sys.stdout.write("%s\n" % error)
 
+		if DATA.daemon:
+			sys.stdout.write("Closing registry daemon...\n")
+			DATA.daemon.set()
+		restoreLogging(_handler)
 
-def _whereami():
-	return ""
+	def parse(self, argv):
+		"""
+		Parses given list of argvs
+
+		Args:
+			argv (list): list of arguments
+
+		Returns:
+			tuple: tuple containing two parts, first one is a command and the second and argument
+		"""
+		if argv[0] in PACKAGES:
+			module = getattr(sys.modules[__name__], argv[0], None)
+			if not module:
+				module = import_module("arky.cli.{0}".format(argv[0]))
+			if hasattr(module, "_whereami"):
+				self.module = module
+				if len(argv) > 1:
+					return self.parse(argv[1:])
+			else:
+				logging.error('Module %s does not have a defined _whereami function', argv[0])
+
+		elif argv[0] in ["exit", ".."]:
+			if self.module.__name__ == 'arky.cli':
+				return False, False
+			else:
+				self.module = sys.modules[__name__]
+
+		elif argv[0] == "EXIT":
+			return False, False
+
+		elif argv[0] in ["help", "?"]:
+			sys.stdout.write("%s\n" % self.module.__doc__.strip())
+
+		elif hasattr(self.module, argv[0]):
+			try:
+				arguments = docopt.docopt(self.module.__doc__, argv=argv)
+			except:
+				arguments = False
+				sys.stdout.write("%s\n" % self.module.__doc__.strip())
+			return getattr(self.module, argv[0]), arguments
+
+		else:
+			sys.stdout.write("Command %s does not exist\n" % argv[0])
+
+		return True, False
 
 
 class Data(object):
@@ -92,45 +188,6 @@ class Data(object):
 DATA = Data()
 
 
-def parse(argv):
-	if argv[0] in PACKAGES:
-		module = getattr(sys.modules[__name__], argv[0], None)
-		if not module:
-			module = import_module("arky.cli.{0}".format(argv[0]))
-		if hasattr(module, "_whereami"):
-			PROMPT.module = module
-			if len(argv) > 1:
-				return parse(argv[1:])
-		else:
-			PROMPT.module = sys.modules[__name__]
-
-	elif argv[0] in ["exit", ".."]:
-		if PROMPT.module == sys.modules[__name__]:
-			return False, False
-		else:
-			PROMPT.module = sys.modules[__name__]
-
-	elif argv[0] == "EXIT":
-		return False, False
-
-	elif argv[0] in ["help", "?"]:
-		sys.stdout.write("%s\n" % PROMPT.module.__doc__.strip())
-
-	elif hasattr(PROMPT.module, argv[0]):
-		try:
-			arguments = docopt.docopt(PROMPT.module.__doc__, argv=argv)
-		except:
-			arguments = False
-			sys.stdout.write("%s\n" % PROMPT.module.__doc__.strip())
-		finally:
-			return getattr(PROMPT.module, argv[0]), arguments
-
-	else:
-		sys.stdout.write("Command %s does not exist\n" % argv[0])
-
-	return True, False
-
-
 def snapLogging():
 	logging.getLogger('requests').setLevel(logging.CRITICAL)
 	logger = logging.getLogger()
@@ -150,56 +207,20 @@ def restoreLogging(handler):
 	logger.addHandler(handler)
 
 
-def start():
-	_handler = snapLogging()
-	sys.stdout.write(
-		'Welcome to arky-cli [Python %(python)s / arky %(arky)s]\n'
-		'Available commands: %(sets)s\n' % {
-			"python": sys.version.split()[0],
-			"arky": __version__,
-			"sets": ", ".join(PACKAGES)
-		}
-	)
-	_xit = False
-	while not _xit:
-		try:
-			command = input(PROMPT)
-		except EOFError:
-			argv = ["EXIT"]
-		else:
-			argv = shlex.split(command)
+def execute(lines):
+	"""
+	Executes command given line by line
 
-		if len(argv) and _Prompt.enable:
-			cmd, arg = parse(argv)
-			if not cmd:
-				_xit = True
-			elif arg:
-				if "link" not in argv:
-					logging.info(command)
-				else:
-					command = censorship(argv)
-					logging.info(command)
-				try:
-					cmd(arg)
-				except Exception as error:
-					if hasattr(error, "__traceback__"):
-						sys.stdout.write("".join(traceback.format_tb(error.__traceback__)).rstrip() + "\n")
-					sys.stdout.write("%s\n" % error)
-
-	if DATA.daemon:
-		sys.stdout.write("Closing registry daemon...\n")
-		DATA.daemon.set()
-
-	restoreLogging(_handler)
-
-
-def execute(*lines):
+	Args:
+		lines: list of commands to execute
+	"""
 	DATA.executemode = True
+	cli = CLI()
 	for line in lines:
-		sys.stdout.write("%s%s\n" % (PROMPT, line))
+		sys.stdout.write("%s%s\n" % (cli.prompt, line))
 		argv = shlex.split(line)
 		if len(argv):
-			cmd, arg = parse(argv)
+			cmd, arg = cli.parse(argv)
 			if cmd and arg:
 				if "link" not in argv:
 					logging.info(line)
@@ -216,10 +237,16 @@ def execute(*lines):
 
 
 def launch(script):
+	"""
+	Script launcher that executed a given script
+
+	Args:
+		script (string): path of the script that we want to execute
+	"""
 	if os.path.exists(script):
-		in_ = io.open(script)
-		execute(*[l.strip() for l in in_.readlines()])
-		in_.close()
+		with io.open(script, "rb") as file:
+			lines = [l.strip() for l in file.readlines()]
+			execute(lines)
 
 
 def askYesOrNo(msg):
@@ -281,7 +308,7 @@ def checkRegisteredTx(registry, folder=None, quiet=False):
 		registered = util.loadJson(registry, folder)
 		if not len(registered):
 			if not quiet:
-				sys.stdout.write("\nNo transaction remaining\n%s" % PROMPT)
+				sys.stdout.write("\nNo transaction remaining\n")
 			LOCK.set()
 		else:
 			if not quiet:
@@ -300,10 +327,10 @@ def checkRegisteredTx(registry, folder=None, quiet=False):
 			remaining = len(registered)
 			if not remaining:
 				if not quiet:
-					sys.stdout.write("\nCheck finished, all transactions applied\n%s" % PROMPT)
+					sys.stdout.write("\nCheck finished, all transactions applied\n")
 				LOCK.set()
 			elif not quiet:
-				sys.stdout.write("\n%d transaction%s not applied in blockchain\nWaiting two blocks (%ds) before another broadcast...\n%s" % (remaining, "s" if remaining > 1 else "", 2 * cfg.blocktime, PROMPT))
+				sys.stdout.write("\n%d transaction%s not applied in blockchain\nWaiting two blocks (%ds) before another broadcast...\n" % (remaining, "s" if remaining > 1 else "", 2 * cfg.blocktime))
 
 	if not quiet:
 		sys.stdout.write("Transaction check in two blocks (%ds)...\n" % (2 * cfg.blocktime))

--- a/arky/cli/ledger.py
+++ b/arky/cli/ledger.py
@@ -32,11 +32,8 @@ from .. import util
 from .. import ldgr
 from .. import slots
 
-from . import PROMPT
 from . import DATA
-from . import parse
 from . import input
-from . import __name__ as __root_name__
 from . import floatAmount
 from . import askYesOrNo
 
@@ -47,6 +44,8 @@ import traceback
 import arky
 import sys
 import os
+
+from arky.exceptions import ParserException
 
 
 def _sign(tx, derivation_path):
@@ -68,12 +67,6 @@ def _sign(tx, derivation_path):
 	return False
 
 
-def _return():
-	sys.stdout.write("Ledger not available on %s network\n" % cfg.network)
-	PROMPT.module = sys.modules[__root_name__]
-	parse(["ledger", ".."])
-
-
 def _whereami():
 	if hasattr(cfg, "slip44"):
 		if DATA.ledger:
@@ -81,8 +74,7 @@ def _whereami():
 		else:
 			return "ledger"
 	else:
-		_return()
-		return ""
+		raise ParserException('Ledger not available on {} network'.format(cfg.network))
 
 
 def link(param):
@@ -102,7 +94,7 @@ def link(param):
 				DATA.ledger["path"] = ledger_dpath
 
 	else:
-		_return()
+		raise ParserException('Ledger not available on {} network'.format(cfg.network))
 
 
 def status(param):

--- a/arky/exceptions.py
+++ b/arky/exceptions.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+"""
+Arky specific exceptions
+"""
+
+
+class ArkyException(Exception):
+    """
+    Base exception for all Arky exceptions
+    """
+
+
+class ParserException(ArkyException):
+    """
+    When something goes wrong in the parser method of the CLI class
+    """

--- a/arky/util.py
+++ b/arky/util.py
@@ -202,9 +202,9 @@ def prettyfy(dic, tab="    "):
 def prettyPrint(dic, tab="    ", log=True):
 	pretty = prettyfy(dic, tab)
 	if len(dic):
-		sys.stdout.write(pretty)
+		sys.stdout.write("%s" % pretty)
 		if log:
-			logging.info("\n" + pretty.rstrip())
+			logging.info("\n %s" % pretty.rstrip())
 	else:
 		sys.stdout.write("%sNothing to print here\n" % tab)
 		if log:

--- a/test/cli/test_cli.py
+++ b/test/cli/test_cli.py
@@ -1,0 +1,71 @@
+# -*- encoding: utf8 -*-
+import unittest
+import mock
+from importlib import import_module
+from parameterized import parameterized
+from arky.cli import CLI
+from arky.exceptions import ParserException
+
+
+class TestCLI(unittest.TestCase):
+
+    @parameterized.expand([
+        (["network"], (True, False)),
+        (["account"], (True, False)),
+        (["delegate"], (True, False)),
+        (["ledger"], (True, False)),
+    ])
+    def test_parse(self, command, expected):
+        cli = CLI()
+        result = cli.parse(command)
+        assert result == expected
+        assert cli.module == import_module("arky.cli.{0}".format(command[0]))
+
+    def test_parse_network(self):
+        cli = CLI()
+        cmd, arg = cli.parse(["network", "use", "dark"])
+        assert cmd.__module__ == "arky.cli.network"
+        assert cmd.__name__ == "use"
+        assert arg["<name>"] == "dark"
+
+    def test_parse_ledger_wrong_network(self):
+        cli = CLI()
+        result = cli.parse(["ledger"])
+        assert result == (True, False)
+        assert cli.module == import_module("arky.cli.ledger")
+        with self.assertRaises(ParserException):
+            cli.prompt
+            assert cli.module == import_module("arky.cli")
+
+    def test_parse_ledger_good_network(self):
+        cli = CLI()
+        cli.parse(["network", "use", "ark"])
+        cmd, arg = cli.parse(["ledger", "link"])
+        assert cmd.__name__ == "link"
+        assert cli.module == import_module("arky.cli.ledger")
+
+    @parameterized.expand(["..", "exit"])
+    def test_parse_back(self, command):
+        cli = CLI()
+        cli.parse(["network"])
+        assert cli.module == import_module("arky.cli.network")
+        result = cli.parse([command])
+        assert result == (True, False)
+        assert cli.module == import_module("arky.cli")
+
+    @parameterized.expand(["help", "?"])
+    def test_parse_help(self, command):
+        cli = CLI()
+        with mock.patch('arky.cli.sys') as sysmock:
+            result = cli.parse([command])
+            assert sysmock.stdout.write.call_count == 1
+        assert result == (True, False)
+
+    @parameterized.expand(["exit", "EXIT"])
+    def test_parse_exit(self, command):
+        cli = CLI()
+        result = cli.parse([command])
+        assert result == (False, False)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/cli/test_cli.py
+++ b/test/cli/test_cli.py
@@ -4,6 +4,7 @@ import mock
 from importlib import import_module
 from arky.cli import CLI
 from arky.exceptions import ParserException
+from arky.rest import use as use_network
 
 
 class TestCLI(unittest.TestCase):
@@ -29,6 +30,7 @@ class TestCLI(unittest.TestCase):
         assert arg["<name>"] == "dark"
 
     def test_parse_ledger_wrong_network(self):
+        use_network("lisk")  # make sure to select a network on which ldgr integration doesn't work
         cli = CLI()
         result = cli.parse(["ledger"])
         assert result == (True, False)

--- a/test/cli/test_cli.py
+++ b/test/cli/test_cli.py
@@ -2,24 +2,24 @@
 import unittest
 import mock
 from importlib import import_module
-from parameterized import parameterized
 from arky.cli import CLI
 from arky.exceptions import ParserException
 
 
 class TestCLI(unittest.TestCase):
 
-    @parameterized.expand([
-        (["network"], (True, False)),
-        (["account"], (True, False)),
-        (["delegate"], (True, False)),
-        (["ledger"], (True, False)),
-    ])
-    def test_parse(self, command, expected):
-        cli = CLI()
-        result = cli.parse(command)
-        assert result == expected
-        assert cli.module == import_module("arky.cli.{0}".format(command[0]))
+    def test_parse(self):
+        scenarios = [
+            (["network"], (True, False)),
+            (["account"], (True, False)),
+            (["delegate"], (True, False)),
+            (["ledger"], (True, False)),
+        ]
+        for command, expected in scenarios:
+            cli = CLI()
+            result = cli.parse(command)
+            assert result == expected
+            assert cli.module == import_module("arky.cli.{0}".format(command[0]))
 
     def test_parse_network(self):
         cli = CLI()
@@ -44,28 +44,28 @@ class TestCLI(unittest.TestCase):
         assert cmd.__name__ == "link"
         assert cli.module == import_module("arky.cli.ledger")
 
-    @parameterized.expand(["..", "exit"])
-    def test_parse_back(self, command):
-        cli = CLI()
-        cli.parse(["network"])
-        assert cli.module == import_module("arky.cli.network")
-        result = cli.parse([command])
-        assert result == (True, False)
-        assert cli.module == import_module("arky.cli")
-
-    @parameterized.expand(["help", "?"])
-    def test_parse_help(self, command):
-        cli = CLI()
-        with mock.patch('arky.cli.sys') as sysmock:
+    def test_parse_back(self):
+        for command in ["..", "exit"]:
+            cli = CLI()
+            cli.parse(["network"])
+            assert cli.module == import_module("arky.cli.network")
             result = cli.parse([command])
-            assert sysmock.stdout.write.call_count == 1
-        assert result == (True, False)
+            assert result == (True, False)
+            assert cli.module == import_module("arky.cli")
 
-    @parameterized.expand(["exit", "EXIT"])
-    def test_parse_exit(self, command):
-        cli = CLI()
-        result = cli.parse([command])
-        assert result == (False, False)
+    def test_parse_help(self):
+        for command in ["help", "?"]:
+            cli = CLI()
+            with mock.patch('arky.cli.sys') as sysmock:
+                result = cli.parse([command])
+                assert sysmock.stdout.write.call_count == 1
+            assert result == (True, False)
+
+    def test_parse_exit(self,):
+        for command in ["exit", "EXIT"]:
+            cli = CLI()
+            result = cli.parse([command])
+            assert result == (False, False)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_ldgr.py
+++ b/test/test_ldgr.py
@@ -95,3 +95,7 @@ class MockedHIDDongleHIDAPI():
 
     def close(self):
         pass
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**Changes:**
- created a CLI object to encapsulate main CLI functionalities, which also made it nicer to test
- fixed stdout.write because in py3 it tries to write bytes which raises an exception]
- fixed the usage of `__doc__`  in the main cli module when writing `help` which I broke (just for the main one) in the previous PR
- changed that we install a specific version of `pipenv==11.1.3` in travis ... the latest version doesn't work in py33. 11.1.3 was the latest version that I found working.

I've also tested the execute script locally and it didn't break it:
```
>>> execute(["network use ark", "network delegates"])
hot@ark/>network use ark
[ark][2018-03-11 10:24:19,932] network use ark
hot@ark/network>network delegates
[ark][2018-03-11 10:24:21,061] network delegates
    #01 - bioly          : 1733782.137
    #02 - arkpool        : 1684092.495
    #03 - biz_classic    : 1647759.164
```

**TODO:**
- [x] pipenv fails to install on py3.3: `error in pipenv setup command: 'install_requires' must be a string or list of strings containing valid `