### PR TITLE
Fix and write tests for: prettyfy, prettyPrint, getBytes and json fns

### DIFF
--- a/arky/ark/crypto.py
+++ b/arky/ark/crypto.py
@@ -221,9 +221,9 @@ def getBytes(tx):
 		if typ == 1 and "signature" in asset:
 			pack_bytes(buf, unhexlify(asset["signature"]["publicKey"]))
 		elif typ == 2 and "delegate" in asset:
-			pack_bytes(buf, asset["delegate"]["username"])
+			pack_bytes(buf, asset["delegate"]["username"].encode())
 		elif typ == 3 and "votes" in asset:
-			pack_bytes(buf, "".join(asset["votes"]))
+			pack_bytes(buf, "".join(asset["votes"]).encode())
 		else:
 			pass
 	# if there is a signature

--- a/arky/util.py
+++ b/arky/util.py
@@ -185,52 +185,51 @@ def shortAddress(addr, sep="...", n=5):
 	return addr[:n] + sep + addr[-n:]
 
 
-def prettyfy(dic, tab="    "):
+def prettyfy(dic, tab='\t'):
 	result = ""
 	if dic:
 		maxlen = max([len(e) for e in dic.keys()])
 		for k, v in dic.items():
 			if isinstance(v, dict):
-				result += tab + "%s:" % k.ljust(maxlen)
+				result += "{0}{1}:".format(tab, k.ljust(maxlen))
 				result += prettyfy(v, tab * 2)
 			else:
-				result += tab + "%s: %s" % (k.rjust(maxlen), v)
+				result += "{0}{1}: {2}".format(tab, k.rjust(maxlen), v)
 			result += "\n"
-		return result.encode("ascii", errors="replace")
+		return result.encode("ascii", errors="replace").decode()
 
 
-def prettyPrint(dic, tab="    ", log=True):
-	pretty = prettyfy(dic, tab)
-	if len(dic):
+def prettyPrint(dic, log=True):
+	pretty = prettyfy(dic)
+	if dic:
 		sys.stdout.write("%s" % pretty)
 		if log:
 			logging.info("\n %s" % pretty.rstrip())
 	else:
-		sys.stdout.write("%sNothing to print here\n" % tab)
+		sys.stdout.write("\tNothing to print here\n")
 		if log:
-			logging.info("%sNothing to log here" % tab)
+			logging.info("\tNothing to log here")
 
 
 def dumpJson(cnf, name, folder=None):
-	filename = os.path.join(HOME if not folder else folder, name)
-	out = io.open(filename, "w")
-	json.dump(cnf, out, indent=2)  # what exactly do we want to do here?
-	out.close()
+	filename = os.path.join(folder or HOME, name)
+	with io.open(filename, "wb") as outfile:
+		outfile.write(json.dumps(cnf).encode())
 	return os.path.basename(filename)
 
 
 def loadJson(name, folder=None):
-	filename = os.path.join(HOME if not folder else folder, name)
+	filename = os.path.join(folder or HOME, name)
 	data = {}
 	if os.path.exists(filename):
 		with io.open(filename, "rb") as file:
 			content = file.read()
-			data = json.loads(content) if content else {}
+			data = json.loads(content.decode()) if content else {}
 	return data
 
 
 def popJson(name, folder=None):
-	filename = os.path.join(HOME if not folder else folder, name)
+	filename = os.path.join(folder or HOME, name)
 	if os.path.exists(filename):
 		os.remove(filename)
 

--- a/test/test_crypto.py
+++ b/test/test_crypto.py
@@ -73,11 +73,26 @@ class TestArkCrypto(unittest.TestCase):
 			)
 		)
 
-	def test_get_bytes(self):
+	def test_get_bytes_and_hexlify(self):
 		self.assertEqual(
 			self.hexaTx,
 			arky.util.hexlify(arky.core.crypto.getBytes(self.tx))
 		)
+
+	def test_get_bytes_for_votes(self):
+		"""
+		Test if we are able to getBytes when we have a unicode (which happens when we want to vote).
+		We don't need to check the value of the `output`, we just care the fn doesn't error
+		"""
+		tx = self.tx.copy()
+		tx["type"] = 3
+		tx.update({
+			"asset": {
+				"votes": [u'+022cca9529ec97a772156c152a00aad155ee6708243e65c9d211a589cb5d43234d']
+			}
+		})
+		output = arky.core.crypto.getBytes(tx)
+		assert output
 
 
 class TestLskCrypto(unittest.TestCase):

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1,9 +1,10 @@
 # -*- encoding: utf8 -*-
-# © Toons
-
+import os
+import io
 import unittest
-
-from arky import rest, cli
+from collections import OrderedDict
+from mock import patch
+from arky import rest, util
 
 
 class TestUtilDef(unittest.TestCase):
@@ -20,6 +21,29 @@ class TestUtilDef(unittest.TestCase):
 		# can' test because `floatAmount` function still seems to be WIP
 		pass
 
+	def test_json(self):
+		"""
+		When calling `dumpJson` a file with a json dump should be created and we should be able to
+		get its contents with `loadJson`. Our `popJson` fn should remove the file.
+		"""
+		data = {"testing": True}
+		filename = "test.txt"
+		util.dumpJson(data, filename)
+		data = util.loadJson(filename)
+		assert data["testing"] is True
+
+		# test if file will be removed
+		util.popJson(filename)
+		assert not os.path.exists(filename)
+
+	def test_prettyPrint(self):
+		# we use OrderedDict to always guarantee the same order as a result so we can assert it
+		data = OrderedDict()
+		data["testing"] = True
+		data["transactions"] = "many"
+		with patch('sys.stdout', new=io.StringIO()) as stdout:
+			util.prettyPrint(data, log=False)
+		assert stdout.getvalue() == '\t     testing: True\n\ttransactions: many\n'
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR fixes errors below and `prettyPrint` + also adds tests for them.

```
arky\util.py", line 42, in pack
return fileobj.write(struct.pack(fmt, *value))
argument for 's' must be a bytes object
```

```
arky\util.py", line 228, in loadJson
    return json.load(file) # if content else {}
  File "C:\Python27\lib\json\__init__.py", line 291, in load
    **kw)
  File "C:\Python27\lib\json\__init__.py", line 339, in loads
    return _default_decoder.decode(s)
  File "C:\Python27\lib\json\decoder.py", line 364, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "C:\Python27\lib\json\decoder.py", line 382, in raw_decode
    raise ValueError("No JSON object could be decoded")
ValueError: No JSON object could be decoded
```

```
util.py", line 228, in loadJson
    return json.load(file) # if content else {}
  File "C:\Program Files (x86)\Python35\lib\json\__init__.py", line 268, in load
    parse_constant=parse_constant, object_pairs_hook=object_pairs_hook, **kw)
  File "C:\Program Files (x86)\Python35\lib\json\__init__.py", line 312, in loads
    s.__class__.__name__))
TypeError: the JSON object must be str, not 'bytes'
```

@Moustikitos 