### PR TITLE
Fix CLI error: isinstance() arg 2 must be a class, type, or tuple of classes and types

### DIFF
--- a/arky/cli/__init__.py
+++ b/arky/cli/__init__.py
@@ -13,6 +13,7 @@ import traceback
 import threading
 from importlib import import_module
 from builtins import input
+from six import PY3
 
 import arky
 from arky import __version__, __FROZEN__, HOME, ROOT, rest, util, cfg
@@ -155,8 +156,15 @@ class Data(object):
 
 	def __setattr__(self, attr, value):
 		if attr == "daemon":
-			if not isinstance(value, threading.Event):
+			if PY3:
+				is_threading = isinstance(value, threading.Event)
+			else:
+				# py2 doesn't support Event object in isinstance
+				is_threading = value.__module__ == 'threading'
+
+			if not is_threading:
 				raise AttributeError("%s value must be a valid %s class" % (value, threading.Event))
+
 			daemon = getattr(self, attr)
 			if daemon:
 				daemon.set()


### PR DESCRIPTION
PY2 doesn't support checking if an object is instance of `threading.Event`, we get the following error when running CLI in py2.

```
hot@dark/network>account link ***************************
isinstance() arg 2 must be a class, type, or tuple of classes and types
```