### PR TITLE
Fix for issue #107

### DIFF
--- a/arky/utils/data.py
+++ b/arky/utils/data.py
@@ -64,29 +64,32 @@ def unScramble(base, data):
 
 
 def dumpAccount(base, address, privateKey, secondPrivateKey=None, name="unamed"):
-    """
-    Store account data into file
-    """
-    folder = os.path.join(HOME, ".account", cfg.network)
-    if not os.path.exists(folder):
-        os.makedirs(folder)
-    filename = os.path.join(folder, name + ".account")
-    data = bytearray()
-    with io.open(filename, "wb") as out:
-        addr = scramble(base, hexlify(address))
-        data.append(len(addr))
-        data.extend(addr)
+	"""
+	Store account data into file
+	"""
+	folder = os.path.join(HOME, ".account", cfg.network)
+	if not os.path.exists(folder):
+		os.makedirs(folder)
+	filename = os.path.join(folder, name + ".account")
+	data = bytearray()
 
-        key1 = scramble(base, privateKey)
-        data.append(len(key1))
-        data.extend(key1)
+	if isinstance(address, str):
+		address = address.encode()
+	addr = scramble(base, hexlify(address))
+	data.append(len(addr))
+	data.extend(addr)
 
-        if secondPrivateKey:
-            key2 = scramble(base, secondPrivateKey)
-            data.append(len(key2))
-            data.extend(key2)
+	key1 = scramble(base, privateKey)
+	data.append(len(key1))
+	data.extend(key1)
 
-        out.write(data)
+	if secondPrivateKey:
+		key2 = scramble(base, secondPrivateKey)
+		data.append(len(key2))
+		data.extend(key2)
+
+	with io.open(filename, "wb") as out:
+		out.write(data)
 
 
 def loadAccount(base, name="unamed"):


### PR DESCRIPTION
This is a fix for #107 

Added encoding an address if it's a string during  dumpAccount().
Moved opening the output file in dumpAccount() to the end so that if creating the output data fails an empty file won't be created. This also keeps the file open for only a short time.