### PR TITLE
Add quit to choose item

### DIFF
--- a/arky/cli/account.py
+++ b/arky/cli/account.py
@@ -132,6 +132,8 @@ def link(param):
 		choices = findAccounts()
 		if choices:
 			name = chooseItem("Account(s) found:", *choices)
+			if not name:
+				return
 			try:
 				data = loadAccount(createBase(hidenInput("Enter pin code: ")), name)
 			except:

--- a/arky/cli/network.py
+++ b/arky/cli/network.py
@@ -47,6 +47,8 @@ def use(param):
 		choices = findNetworks()
 		if choices:
 			param["<name>"] = chooseItem("Network(s) found:", *choices)
+			if not param["<name>"]:
+				return
 		else:
 			sys.stdout.write("No Network found\n")
 			return False

--- a/arky/rest.py
+++ b/arky/rest.py
@@ -242,7 +242,7 @@ def use(network, **kwargs):
         with io.open(os.path.join(ROOT, "net", network + ".net")) as f:
             data = json.load(f)
     else:
-        return "File not found for {}".format(network)
+        raise Exception("File not found for {}".format(network))
 
     data.update(**kwargs)
 

--- a/arky/utils/cli.py
+++ b/arky/utils/cli.py
@@ -33,13 +33,17 @@ def chooseItem(msg, *elem):
         sys.stdout.write(msg + "\n")
         for i in range(n):
             sys.stdout.write("    %d - %s\n" % (i + 1, elem[i]))
-        i = 0
-        while i < 1 or i > n:
+        sys.stdout.write("    0 - quit\n")
+        i = -1
+        while i < 0 or i > n:
             try:
                 i = input("Choose an item: [1-%d]> " % n)
                 i = int(i)
             except:
-                i = 0
+                i = -1
+        if i == 0:
+            # Quit without making a selection
+            return False
         return elem[i - 1]
     elif n == 1:
         return elem[0]

--- a/test/test_rest.py
+++ b/test/test_rest.py
@@ -35,7 +35,9 @@ class TestRest(unittest.TestCase):
         """
         Test if error is raised
         """
-        assert arky.rest.use('not-a-blockchain') == 'File not found for not-a-blockchain'
+        with self.assertRaises(Exception) as context:
+            arky.rest.use('not-a-blockchain')
+        assert str(context.exception) == 'File not found for not-a-blockchain'
 
 
     @responses.activate

--- a/test/utils/test_cli.py
+++ b/test/utils/test_cli.py
@@ -29,6 +29,11 @@ class TestUtilsCLI(unittest.TestCase):
         output = chooseItem("Network(s) found:", *["ark", "dark", "lisk"])
         assert output == "dark"
 
+    @patch('arky.utils.cli.input', return_value="0")
+    def test_chooseItemQuit(self, input):
+        output = chooseItem("Network(s) found:", *["ark", "dark", "lisk"])
+        assert output == False
+
     def test_chooseMultipleItem(self):
         scenarios = [
             ("1, 2", [1, 2]),


### PR DESCRIPTION
I added the option to quit the selection when chooseItem() is called. I set the quit option as selection 0. An example would prompt looks like so:

> Network(s) found:
>     1 - tshift
>     2 - ark
>     3 - toxy
>     4 - lwf
>     5 - ark-aip11
>     6 - oxy
>     7 - tlwf
>     8 - kapu
>     9 - lisk
>     10 - shift
>     11 - dark
>     0 - quit
> Choose an item: [1-11]> 


I did not change the "Choose an item" prompt because I thought it would get too verbose. We could always make it start at 0 instead of 1 if you would like that.
