### PR TITLE
Fix for issue 112

### DIFF
--- a/arky/cli/account.py
+++ b/arky/cli/account.py
@@ -45,7 +45,7 @@ import os
 import sys
 
 import arky
-from arky import cfg, HOME, rest
+from arky import cfg, HOME, rest, exceptions
 from arky.cli import checkSecondKeys, checkRegisteredTx, floatAmount, DATA, askYesOrNo
 from arky.util import getDelegatesPublicKeys
 from arky.utils.cli import prettyPrint, shortAddress, chooseItem, hidenInput, chooseMultipleItem
@@ -136,7 +136,7 @@ def link(param):
 				return
 			try:
 				data = loadAccount(createBase(hidenInput("Enter pin code: ")), name)
-			except:
+			except exceptions.BadPinError:
 				sys.stdout.write("    Bad pin code...\n")
 				return
 			else:

--- a/arky/cli/account.py
+++ b/arky/cli/account.py
@@ -135,7 +135,7 @@ def link(param):
 			if not name:
 				return
 			try:
-				data = loadAccount(createBase(hidenInput("Enter pin code: ")), name)
+				data = loadAccount(createBase(hidenInput("Enter pin code for %s: " % name)), name)
 			except exceptions.BadPinError:
 				sys.stdout.write("    Bad pin code...\n")
 				return

--- a/arky/exceptions.py
+++ b/arky/exceptions.py
@@ -14,3 +14,9 @@ class ParserException(ArkyException):
     """
     When something goes wrong in the parser method of the CLI class
     """
+
+
+class BadPinError(ArkyException):
+    """
+    When a bad pin is entered when linking an account with a file
+    """

--- a/arky/utils/data.py
+++ b/arky/utils/data.py
@@ -12,16 +12,22 @@ def findNetworks():
     """
     Gets a list of all available networks
     """
+    path = os.path.join(ROOT, "net")
+    if not os.path.exists(path):
+        return []
     networks = []
-    for name in os.listdir(os.path.join(ROOT, "net")):
+    for name in os.listdir(path):
         if name.endswith(".net"):
             networks.append(os.path.splitext(name)[0])
     return networks
 
 
 def findAccounts():
+    path = os.path.join(HOME, ".account", cfg.network)
+    if not os.path.exists(path):
+        return []
     accounts = []
-    for name in os.listdir(os.path.join(HOME, ".account", cfg.network)):
+    for name in os.listdir(path):
         if name.endswith(".account"):
             accounts.append(os.path.splitext(name)[0])
     return accounts

--- a/test/utils/test_data.py
+++ b/test/utils/test_data.py
@@ -61,10 +61,13 @@ class TestUtilsData(unittest.TestCase):
         privateKey = "123123123"
         base = createBase(pin)
 
+        orig_accounts = findAccounts()
+        orig_accounts.append("unamed")
+
         dumpAccount(base, address, privateKey)
 
         accounts = findAccounts()
-        assert accounts == ["unamed"]
+        assert set(accounts) == set(orig_accounts)
 
         output = loadAccount(base)
         assert output["address"] == address

--- a/test/utils/test_data.py
+++ b/test/utils/test_data.py
@@ -2,6 +2,7 @@
 import os
 import unittest
 
+from arky.exceptions import BadPinError
 from arky.rest import use
 from arky.utils.bin import hexlify
 from arky.utils.data import (
@@ -68,6 +69,22 @@ class TestUtilsData(unittest.TestCase):
         output = loadAccount(base)
         assert output["address"] == address
         assert output["privateKey"] == privateKey
+
+    def test_loadAccount_badPin(self):
+        use("dark")
+
+        pin = "abc123"
+        address = "DUGvQBxLzQqrNy68asPcU3stWQyzVq8G49".encode()
+        privateKey = "123123123"
+        base = createBase(pin)
+
+        dumpAccount(base, address, privateKey)
+
+        badPin = "xyz123"
+        badBase = createBase(badPin)
+
+        with self.assertRaises(BadPinError) as context:
+            loadAccount(badBase)
 
     def test_findNetworks(self):
         networks = findNetworks()


### PR DESCRIPTION
This is a fix for #112 

* Added a hash of the address when saving an account.
* Updated loadAccount() to check the unscrambled address hash against the hash saved to the file.
* Added a custom exception for when a bad pin is entered when linking an account.
* Added a test for a bad pip
* Updated the original loadAccount() test so that it can work if there are already accounts saved.