### PR TITLE
Correct WIF byte marker for DARK addresses

### DIFF
--- a/arky/net/dark.net
+++ b/arky/net/dark.net
@@ -7,7 +7,7 @@
   "maxvotepertx": 1,
 
   "compressed": true,
-  "wif": "ef",
+  "wif": "aa",
   "marker": "1e",
   "slip44": "111",
   "bip32": {


### PR DESCRIPTION
Updated devnet WIF byte marker to match Ark Core.